### PR TITLE
Add cstring header + use modern C++ header

### DIFF
--- a/MultipartParser.h
+++ b/MultipartParser.h
@@ -4,6 +4,7 @@
 #include <sys/types.h>
 #include <string>
 #include <stdexcept>
+#include <cstring>
 
 class MultipartParser {
 public:

--- a/multipart.cpp
+++ b/multipart.cpp
@@ -3,9 +3,10 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
-#include <stdio.h>
+#include <cstdio>
 #include <unistd.h>
-#include <stdlib.h>
+#include <cstdlib>
+#include <cstring>
 
 //#define TEST_PARSER
 #define INPUT_FILE "input3.txt"


### PR DESCRIPTION
In this library, `memset` is used two times. It is defined in `<cstring>` header by the standard
http://www.cplusplus.com/reference/cstring/memset/
which isn't included in any files, which makes library unable to be compiled in g++ compiler.

```
g++ -Wall -g multipart.cpp -o multipart
In file included from multipart.cpp:1:0:
MultipartParser.h: In member function ‘void MultipartParser::indexBoundary()’:
MultipartParser.h:71:49: error: ‘memset’ was not declared in this scope
   memset(boundaryIndex, 0, sizeof(boundaryIndex));
```

I added `<cstring>` include + replaced c headers with c++ headers (`<stdio.h>` to `<cstdio>`, `<stdlib.h>` to `<cstdlib>`)
